### PR TITLE
Add switch that disables repo installation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 sansible_mosquitto_aws_enabled: no
 sansible_mosquitto_aws_region: eu-west-1
 sansible_mosquitto_aws_s3_files: []
+sansible_mosquitto_repoinstall_enabled: yes
 sansible_mosquitto_install_clients: no
 sansible_mosquitto_limits_nofile_hard: 65535
 sansible_mosquitto_limits_nofile_soft: 65535

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-
+sansible_mosquitto_conf_destination: "/etc/mosquitto/conf.d/mosquitto.local.conf"
 sansible_mosquitto_aws_enabled: no
 sansible_mosquitto_aws_region: eu-west-1
 sansible_mosquitto_aws_s3_files: []

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -36,6 +36,6 @@
   become: yes
   template:
     src: mosquitto.local.conf.j2
-    dest: /etc/mosquitto/conf.d/mosquitto.local.conf
+    dest: "{{ sansible_mosquitto_conf_destination }}"
   notify:
     - restart mosquitto

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,6 +7,8 @@
     state: present
     update_cache: yes
     validate_certs: no
+  when:
+    - sansible_mosquitto_repoinstall_enabled | bool
 
 - name: Ensure Mosquitto service is installed
   become: yes


### PR DESCRIPTION
Hi, on some systems the repo installation failed due to the non existent packages for that distribution or system version. Also it would be cool to disable dev repo and use production instead.

Example:
```
TASK [sansible.mosquitto : Add Mosquitto repository] ********************************************************************************
fatal: [newfhem]: FAILED! => {"changed": false, "msg": "Failed to update apt cache: E:The repository 'http://ppa.launchpad.net/mosquitto-dev/mosquitto-ppa/ubuntu stretch Release' does not have a Release file."}
```

I added a switch for that in this PR. Feel free to merge this to development for automated testing and move it to production.